### PR TITLE
Change oversight to suppress

### DIFF
--- a/markAdmins-core.js
+++ b/markAdmins-core.js
@@ -56,7 +56,7 @@ var markAdmins = mw.libs.markAdmins = {
 				legacyLabelId: 'iatxt',
 				enabled: true
 			},
-			'oversight': {
+			'suppress': {
 				label: 'OS',
 				legacyName: 'oversight',
 				legacyLabelId: 'oversighttxt',


### PR DESCRIPTION
Changes the oversight group to suppress following WMF's internal rename. See https://phabricator.wikimedia.org/T112147 for more information, and https://github.com/mdaniels5757/MDanielsBot-MarkAdminsListUpdater/pull/2 for the accompanying patch on the bots code.